### PR TITLE
fix(backend): flush manquant sur création de bénéficiaire

### DIFF
--- a/backend/src/State/Utilisateur/UtilisateurManager.php
+++ b/backend/src/State/Utilisateur/UtilisateurManager.php
@@ -623,7 +623,7 @@ readonly class UtilisateurManager
         //On copie les données récupérables dans la demande
         $this->copierDonneesDemande($demande);
 
-        $this->utilisateurRepository->save($beneficiaire->getUtilisateur());
+        $this->utilisateurRepository->save($beneficiaire->getUtilisateur(), true);
 
         return $beneficiaire;
     }


### PR DESCRIPTION
Sans cette correction le bouton "voir le bénéficiaire" sur les demandes n'apparait pas immédiatement après validation de la demande.