### PR TITLE
fix(backend): invalidation de cache incomplète 

### DIFF
--- a/backend/src/ApiResource/Demande.php
+++ b/backend/src/ApiResource/Demande.php
@@ -141,6 +141,10 @@ class Demande
     #[Assert\NotNull(message: 'Impossible si le DemandeDenormalizer fait son job')]
     public ?Utilisateur $demandeur = null;
 
+    public string $uid {
+        get => $this->demandeur->uid;
+    }
+
     #[Groups([self::GROUP_OUT])]
     public CampagneDemande $campagne;
 

--- a/backend/src/ApiResource/Utilisateur.php
+++ b/backend/src/ApiResource/Utilisateur.php
@@ -192,6 +192,10 @@ final class Utilisateur
     ])]
     public string $uid;
 
+    public ?string $roleId = null {
+        get => $this->roleId ?? $this->roles[0];
+    }
+
     #[Groups([
         self::GROUP_OUT,
         self::AMENAGEMENTS_UTILISATEURS_OUT,

--- a/backend/src/Service/HttpCacheInvalidator.php
+++ b/backend/src/Service/HttpCacheInvalidator.php
@@ -13,8 +13,11 @@
 namespace App\Service;
 
 use ApiPlatform\HttpCache\PurgerInterface;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\IriConverterInterface;
-use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use Exception;
 use Psr\Log\LoggerInterface;
@@ -23,7 +26,8 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 readonly class HttpCacheInvalidator
 {
     public function __construct(private IriConverterInterface                                                        $iriConverter,
-                                private OperationMetadataFactoryInterface                                            $operationMetadataFactory,
+                                private ResourceClassResolverInterface                                               $resourceClassResolver,
+                                private ResourceMetadataCollectionFactoryInterface                                   $resourceMetadataCollectionFactory,
                                 #[Autowire(service: 'api_platform.http_cache.purger.souin')] private PurgerInterface $httpCachePurger,
                                 private LoggerInterface                                                              $logger)
     {
@@ -32,32 +36,34 @@ readonly class HttpCacheInvalidator
 
     public function invalidateCollectionForRessource($resource): void
     {
-        // si la ressource n'a pas de GetCollection, on sort
-        if (!defined(get_class($resource) . '::COLLECTION_URI')) {
-            return;
-        }
-
-        $collectionUriTemplate = get_class($resource)::COLLECTION_URI;
-
-        $collectionOperation = $this->operationMetadataFactory->create($collectionUriTemplate, []);
-        $collectionUri = $this->iriConverter->getIriFromResource($resource, UrlGeneratorInterface::ABS_PATH, $collectionOperation);
-        try {
-            $this->httpCachePurger->purge([$collectionUri]);
-            $this->logger->info("Invalidated collection for ressource : $collectionUri");
-        } catch (Exception) {
-            //sans cache disponible on évite de planter...
-        }
+        $this->invalidate($resource, GetCollection::class);
     }
 
     public function invalidateRessource($resource): void
     {
-        $itemIri = $this->iriConverter->getIriFromResource($resource);
-        try {
-            $this->httpCachePurger->purge([$itemIri]);
-            $this->logger->info("Invalidated item for ressource : $itemIri");
-        } catch (Exception) {
-            //sans cache disponible on évite de planter...
+        $this->invalidate($resource, Get::class);
+    }
+
+
+    private function invalidate(object $resource, string $type): void
+    {
+        $resourceClass = $this->resourceClassResolver->getResourceClass($resource);
+        $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
+
+        foreach ($resourceMetadataCollection as $resourceMetadata) {
+            foreach ($resourceMetadata->getOperations() ?? [] as $operation) {
+                if ($operation instanceof $type) {
+                    $targetUri = $this->iriConverter->getIriFromResource($resource, UrlGeneratorInterface::ABS_PATH, $operation);
+                    try {
+                        $this->httpCachePurger->purge([$targetUri]);
+                        $this->logger->info("Invalidated uri for ressource : $targetUri");
+                    } catch (Exception) {
+                        //sans cache disponible, on évite de planter...
+                    }
+                }
+            }
         }
+
     }
 
 }

--- a/backend/src/State/Demande/PatchDemandeProcessor.php
+++ b/backend/src/State/Demande/PatchDemandeProcessor.php
@@ -14,7 +14,10 @@ namespace App\State\Demande;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BeneficiaireProfil;
 use App\ApiResource\Demande;
+use App\Entity\EtatDemande;
+use App\Message\RessourceCollectionModifieeMessage;
 use App\Message\RessourceModifieeMessage;
 use App\State\TransformerService;
 use Exception;
@@ -47,6 +50,15 @@ readonly class PatchDemandeProcessor implements ProcessorInterface
                 profilId: $data->profilAttribue?->id,
                 user: $this->security->getUser()
             );
+            //si nouvel état = validé, on veut refresh le cache!
+            if ($data->etat->id === EtatDemande::VALIDEE) {
+                $beneficiaire = $this->transformerService->transform($demande->getDemandeur()->getBeneficiairesActifs()[0], BeneficiaireProfil::class);
+                $this->messageBus->dispatch(new RessourceModifieeMessage($beneficiaire));
+                $this->messageBus->dispatch(new RessourceModifieeMessage($data->demandeur));
+                $this->messageBus->dispatch(new RessourceCollectionModifieeMessage($beneficiaire));
+                $this->messageBus->dispatch(new RessourceCollectionModifieeMessage($data->demandeur));
+            }
+
         } else {
             $this->demandeManager->ajouterCommentaire($demande, $data->commentaire);
         }

--- a/backend/src/State/Demande/PatchDemandeProcessor.php
+++ b/backend/src/State/Demande/PatchDemandeProcessor.php
@@ -53,10 +53,15 @@ readonly class PatchDemandeProcessor implements ProcessorInterface
             //si nouvel état = validé, on veut refresh le cache!
             if ($data->etat->id === EtatDemande::VALIDEE) {
                 $beneficiaire = $this->transformerService->transform($demande->getDemandeur()->getBeneficiairesActifs()[0], BeneficiaireProfil::class);
+                $demandeur = $data->demandeur;
+                $demandeur->roleId = 'ROLE_DEMANDEUR';
                 $this->messageBus->dispatch(new RessourceModifieeMessage($beneficiaire));
-                $this->messageBus->dispatch(new RessourceModifieeMessage($data->demandeur));
+                $this->messageBus->dispatch(new RessourceModifieeMessage($demandeur));
                 $this->messageBus->dispatch(new RessourceCollectionModifieeMessage($beneficiaire));
-                $this->messageBus->dispatch(new RessourceCollectionModifieeMessage($data->demandeur));
+                $this->messageBus->dispatch(new RessourceCollectionModifieeMessage($demandeur));
+                $demandeur->roleId = 'ROLE_BENEFICIAIRE';
+                $this->messageBus->dispatch(new RessourceModifieeMessage($demandeur));
+                $this->messageBus->dispatch(new RessourceCollectionModifieeMessage($demandeur));
             }
 
         } else {


### PR DESCRIPTION
Quand il y a plusieurs opérations Get/GetCollection sur la même ressource, il faut invalider toutes les URIs, pas seulement la principale...