### PR TITLE
feat: personnalisation du champ ldap contenant le numéro étudiant

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -75,6 +75,7 @@ LDAP_PASSWORD=
 LDAP_DN='ou=people,dc=univ, dc=fr'
 LDAP_CHAMPS_RECHERCHE='["uid", "cn"]'
 LDAP_CRITERES_RECHERCHE_SUP="(eduPersonAffiliation=member)"
+LDAP_CHAMP_ETU_ID='supannetuid'
 ###< LDAP ###
 
 ###> APOGEE ###

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -82,6 +82,9 @@ disponibles dans le fichier
 * **LDAP_USERNAME** : nom d'utilisateur pour connexion au LDAP
 * **LDAP_PASSWORD** : mot de passe de connexion au LDAP
 * **LDAP_DN** : base dans laquelle rechercher les individus dans le LDAP
+* **LDAP_CHAMPS_RECHERCHE** : champs utilisés pour la recherche d'individus
+* **LDAP_CRITERES_RECHERCHE_SUP** : Filtre additionnel pour la recherche
+* **LDAP_CHAMP_ETU_ID** : Champ contenant le numéro étudiant
 * **MAILER_DSN** : DSN du serveur smtp (`smtp://user:password@server:port`)
 * **GOTENBERG_DSN** : URL de l'instance Gotenberg
 * **APOGEE_USER** : utilisateur avec droits de lecture dans la base Apogée

--- a/docs/backend/connecteurs.md
+++ b/docs/backend/connecteurs.md
@@ -13,7 +13,7 @@ Le seul champ utilisé est l'id de l'utilisateur, qui doit correspondre au champ
 L'annuaire LDAP est utilisé dans plusieurs contextes :
 
 * lors de l'authentification d'un utilisateur non déjà connu, récupération des champs `uid`,  `sn`, `givenname`, `mail`
-  et `supannetuid`.
+  et du champ pointé par la variable d'environnement LDAP_CHAMP_ETU_ID (`supannetuid` par défaut).
 * lors de la recherche d'un utilisateur en vue de lui attribuer un rôle, recherche textuelle sur les champs
   `uid` et `cn` (par défaut, cf plus bas) pour récupération des mêmes champs que précédemment.
 


### PR DESCRIPTION
Fixes #28 

Ajout de paramètres de configuration pour les établissements n'utilisant pas supannetuid pour stocker les numéros étudiants dans leur annuaire.