### PR TITLE
chore: correctif CVE frankenphp

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1.12.2-builder-php8.5 AS builder
+FROM dunglas/frankenphp:1.12.3-builder-php8.5 AS builder
 COPY --from=caddy:builder /usr/bin/xcaddy /usr/bin/xcaddy
 
 RUN apt-get update && \
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=1 \
     --with github.com/darkweak/souin/plugins/caddy \
     --with github.com/darkweak/storages/otter/caddy
 
-FROM dunglas/frankenphp:1.12.2-php8.5 AS frankenphp_upstream
+FROM dunglas/frankenphp:1.12.3-php8.5 AS frankenphp_upstream
 COPY --from=builder --link /usr/local/bin/frankenphp /usr/local/bin/frankenphp
 
 #force non-https, TZ, ...

--- a/backend/Dockerfile-dev
+++ b/backend/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1.12.2-builder-php8.5 AS builder
+FROM dunglas/frankenphp:1.12.3-builder-php8.5 AS builder
 COPY --from=caddy:builder /usr/bin/xcaddy /usr/bin/xcaddy
 
 RUN apt-get update && apt-get install --no-install-recommends -y git
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=1 \
     --with github.com/darkweak/souin/plugins/caddy \
     --with github.com/darkweak/storages/otter/caddy
 
-FROM dunglas/frankenphp:1.12.2-php8.5 AS frankenphp_upstream
+FROM dunglas/frankenphp:1.12.3-php8.5 AS frankenphp_upstream
 COPY --from=builder /usr/local/bin/frankenphp /usr/local/bin/frankenphp
 
 #force non-https


### PR DESCRIPTION
Montée de version frankenphp pour correctif de sécurité : https://github.com/php/frankenphp/security/advisories/GHSA-3g8v-8r37-cgjm